### PR TITLE
Fix Null Template error when nw-notify is a transitive dependency and…

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,8 +121,8 @@ function getAppPath() {
 }
 
 function updateTemplatePath() {
-	var appPath = getAppPath();
-	config.templatePath = appPath + 'node_modules/nw-notify/notification.html';
+	var appPath = "file:///"+__dirname;
+	config.templatePath = appPath + '/notification.html';
 	return config.templatePath;
 }
 

--- a/index.js
+++ b/index.js
@@ -121,8 +121,8 @@ function getAppPath() {
 }
 
 function updateTemplatePath() {
-	var appPath = "file:///"+__dirname;
-	config.templatePath = appPath + '/notification.html';
+	var scriptPath = "file:///"+__dirname;
+	config.templatePath = scriptPath + '/notification.html';
 	return config.templatePath;
 }
 


### PR DESCRIPTION
… template path has not been set

Basically, the module will always find notification.html, by referring to the installation directory of index.js ( Using __dirname ) and not the runnning application ( Using getAppPath() )

![transitive_dependency_error](https://cloud.githubusercontent.com/assets/5859565/10536103/1de6cb2a-73f1-11e5-88f5-0c942dab8c1f.PNG)
