### PR TITLE
Fixed auto cleanup freeze

### DIFF
--- a/index.js
+++ b/index.js
@@ -592,7 +592,9 @@ function log(){
 gui.Window.get().on('close', function() {
   if (config.autoCleanup) {
     closeAll()
-    gui.App.quit()
+	setTimeout(function() {
+		gui.App.quit();
+	}, 1000);
   }
 })
 


### PR DESCRIPTION
If a notification was active while you closed the app, sometimes the app
would freeze and just stay on for about 10-20 seconds and then close,
this will let the closeall function close all the windows in time before
we call gui.app.quit which actually creates the freeze if we are in the
process of closing a window.

Simple fix yet effective.
