### PR TITLE
Fixed auto cleanup freeze PROPERLY UNTESTED

### DIFF
--- a/index.js
+++ b/index.js
@@ -565,19 +565,21 @@ function setStyleOnDomElement(styleObj, domElement){
   }
 }
 
-function closeAll() {
-  // Clear out animation Queue and close windows
+function closeAll(callback) {
   animationQueue.clear()
-  _.forEach(activeNotifications, function(window) {
+
+  async.each(_.merge(activeNotifications, inactiveWindows), function(window, done) {
     window.close()
-  })
-  _.forEach(inactiveWindows, function(window) {
-    window.close()
-  })
-  // Reset certain vars
-  nextInsertPos = {}
-  activeNotifications = []
-  inactiveWindows = []
+    done();
+  }, function() {
+    // Reset certain vars
+    nextInsertPos = {}
+    activeNotifications = []
+    inactiveWindows = []
+    if(typeof callback === 'function') {
+      return callback();
+    }
+  });
 }
 
 function log(){
@@ -591,10 +593,9 @@ function log(){
  */
 gui.Window.get().on('close', function() {
   if (config.autoCleanup) {
-    closeAll()
-	setTimeout(function() {
-		gui.App.quit();
-	}, 1000);
+    closeAll(function() {
+      gui.App.quit();
+    });
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -592,7 +592,9 @@ function log(){
 gui.Window.get().on('close', function() {
   if (config.autoCleanup) {
     closeAll()
-    gui.App.quit()
+	setTimeout(function() {
+		gui.App.quit();
+	}, 1000);
   }
 })
 


### PR DESCRIPTION
If a notification was active while you closed the app, sometimes the app
would freeze and just stay on for about 10-20 seconds and then close,
this will let the closeall function close all the windows in time before
we call gui.app.quit which actually creates the freeze if we are in the
process of closing a window.

THIS IS UNTESTED
